### PR TITLE
Detect event handler attribute keys

### DIFF
--- a/src/preact-render-spy.js
+++ b/src/preact-render-spy.js
@@ -1,7 +1,5 @@
 const {render} = require('preact');
 
-const events = require('./events');
-
 const spyWalk = (spy, vdom) => {
   if (typeof vdom.nodeName === 'function' && !vdom.nodeName.isSpy) {
     vdom = Object.assign({}, vdom, {nodeName: createSpy(spy, vdom.nodeName)});
@@ -97,9 +95,14 @@ class FindWrapper {
   simulate(event, ...args) {
     for (let i = 0; i < this.length; i++) {
       const vdom = this.spy._getVDom(this[i]);
-      const handle = vdom.attributes && vdom.attributes[events[event]];
-      if (handle) {
-        handle(...args);
+      const eventlc = event.toLowerCase();
+      const eventKeys = new Set([`on${eventlc}`, `on${eventlc}capture`];
+      
+      for (const key in vdom.attributes) {
+        if (eventKeys.has(key.toLowerCase()) {
+            vdom.attributes[key](...args);
+            break;
+        }
       }
     }
     return new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
Events when bound take the `onAnyCaptialize` -> `addEventListener('anycapitialize')` and `onSomethingCapture` for `'something'` in capture mode pattern in preact, so we can simulate any event by just looking for a method called one of these two things