### PR TITLE
Allow searching for components by displayName even if lowercased

### DIFF
--- a/src/is-where.js
+++ b/src/is-where.js
@@ -7,11 +7,11 @@ const _isWhere = (where, target) => {
       all = all && Boolean(target[key]) && _isWhere(value, target[key]);
     }
     else if (key === 'nodeName') {
-      if (/[a-z]/.test(value[0])) {
-        all = all && target.nodeName === value;
+      if (typeof target.nodeName === 'function') {
+        all = all && (target.nodeName.name === value || target.nodeName.displayName === value);
       }
-      else if (typeof target.nodeName === 'function') {
-        all = all && target.nodeName.name === value;
+      else if (/[a-z]/.test(value[0])) {
+        all = all && target.nodeName === value;
       }
       else {
         all = false;
@@ -29,6 +29,10 @@ const _isWhere = (where, target) => {
       else {
         all = all && Boolean(target) && target[key] === value;
       }
+    }
+    // break the loop if we hit any falsyness
+    if (!all) {
+      break;
     }
   }
   return all;

--- a/src/is-where.test.js
+++ b/src/is-where.test.js
@@ -10,9 +10,13 @@ it('tests Component names', () => {
   class Node extends Component {}
   const NodelessConst = () => {};
   function NodelessFunc() {}
+  function DisplayNamedFunc() {}
+  DisplayNamedFunc.displayName = 'displayName';
+
   expect(isWhere({nodeName: 'Node'})(<Node />)).toBeTruthy();
   expect(isWhere({nodeName: 'NodelessConst'})(<NodelessConst />)).toBeTruthy();
   expect(isWhere({nodeName: 'NodelessFunc'})(<NodelessFunc />)).toBeTruthy();
+  expect(isWhere({nodeName: 'displayName'})(<DisplayNamedFunc />)).toBeTruthy();
 });
 
 it('tests nested attributes', () => {


### PR DESCRIPTION
I've seen this before with some libs using display names like`wrapped(Component)` when you create a wrapped component