### PR TITLE
Wrap root rendered component to allow rerender

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ This will return you a [`FindWrapper`](#findwrapper) which has other useful meth
 Like [`#find(selector)`](#rendercontextfindselector) `RenderContext` has the rest of `FindWrapper`'s methods.
 
 ### `RenderContext#render(jsx)`
-Re-renders the root level jsx node using the same depth initially requested.  **NOTE:** When preact re-renders this way,
-it will not reuse components, so if you want to test `componentWillReceiveProps` you will need to use a test wrapper component.
+Re-renders the root level jsx node using the same depth initially requested.  This can be useful for testing
+`componentWillReceiveProps` hooks.
 
 Example:
 

--- a/src/preact-render-spy.js
+++ b/src/preact-render-spy.js
@@ -290,7 +290,7 @@ const setHiddenProp = (object, prop, value) => {
     value,
   });
   return value;
-}
+};
 
 class RenderContext extends FindWrapper {
   constructor({depth}) {

--- a/src/preact-render-spy.js
+++ b/src/preact-render-spy.js
@@ -274,12 +274,15 @@ const setHiddenProp = (object, prop, value) => {
 };
 
 class ContextRootWrapper extends Component {
-  constructor({ vdom, context }) {
-    super({ vdom, context });
+  constructor(props) {
+    super(props);
+
+    const { vdom, renderRef } = props;
     this.state = {vdom};
 
-    // setup the re-renderer on the RenderContext
-    setHiddenProp(context, 'contextRender', vdom => {
+    // setup the re-renderer - call the `renderRef` callback with a
+    // function that will re-render the content here
+    renderRef(vdom => {
       this.setState({ vdom });
       rerender();
     });
@@ -308,7 +311,7 @@ class RenderContext extends FindWrapper {
       nodeName: ContextRootWrapper,
       attributes: {
         vdom: null,
-        context: this,
+        renderRef: contextRender => setHiddenProp(this, 'contextRender', contextRender),
       },
     }, this.fragment);
 

--- a/src/preact-render-spy.js
+++ b/src/preact-render-spy.js
@@ -305,26 +305,23 @@ class RenderContext extends FindWrapper {
       setHiddenProp(this, prop, new Map());
     });
 
+    // Render an Empty ContextRootWrapper and get it's rerender method:
+    render({
+      nodeName: ContextRootWrapper,
+      attributes: {
+        vdom: null,
+        rerenderHook: contextRender => setHiddenProp(this, 'contextRender', contextRender),
+      },
+    }, this.fragment);
+
   }
 
   render(vdom) {
-    const spiedDom = spyWalk(this, setVDom(this, 'root', vdom), 0);
     // Add what we need to be a FindWrapper:
     this[0] = vdom;
     this.length = 1;
+    this.contextRender(spyWalk(this, setVDom(this, 'root', vdom), 0));
 
-    // If we have a root component, have it update the state
-    if (this.contextRender) {
-      this.contextRender(spiedDom);
-    } else {
-      render({
-        nodeName: ContextRootWrapper,
-        attributes: {
-          vdom: spiedDom,
-          rerenderHook: contextRender => setHiddenProp(this, 'contextRender', contextRender),
-        },
-      }, this.fragment);
-    }
     return this;
   }
 }

--- a/src/shared-render.test.js
+++ b/src/shared-render.test.js
@@ -3,6 +3,23 @@ const {h, Component} = require('preact');
 const {deep, shallow} = require('./preact-render-spy');
 
 const sharedTests = (name, func) => {
+  class ReceivesProps extends Component {
+    constructor(props) {
+      super(props);
+      this.state = {value: props.value};
+    }
+
+    componentWillReceiveProps(newProps) {
+      this.setState({value: `_${newProps.value}_`});
+    }
+
+    render(props, {value}) {
+      return (
+        <div>{value}</div>
+      );
+    }
+  }
+
   class Div extends Component {
     render() {
       return <div />;
@@ -152,6 +169,13 @@ const sharedTests = (name, func) => {
     const context = func(<DivChildren><div>foo</div><div>bar</div></DivChildren>);
     expect(context.text()).toBe('foobar');
     expect(context.find('div').at(0).text()).toBe('foobar');
+  });
+
+  it(`${name}: will call componentWillReceiveProps on the 'root' node`, () => {
+    const context = func(<ReceivesProps value="test" />);
+    expect(context.text()).toBe('test');
+    context.render(<ReceivesProps value="received" />);
+    expect(context.text()).toBe('_received_');
   });
 };
 


### PR DESCRIPTION
This sets it up to rerender the root nodes and verifies that `componentWillReceiveProps` happens on "rerender" 

Fixes #25 