### PR TITLE
Recurse the output to depth rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,20 @@ Returns the flattened string of any text children of any child component.
 Looks for an attribute properly named `onEvent` or `onEventCapture` and calls it, passing the arguments.
 
 ### `FindWrapper#output()`
-Requires a single Component or functional node. Returns the raw vdom output of the given component.
+Requires a single Component or functional node. Returns the vdom output of the given component.
+Any Component or functional nodes will be "recursive" up to the depth you specified.  I.E.:
+
+Example:
+```jsx
+
+const Second = ({ children }) => <div>second {children}</div>;
+const First = () => <Second>first</Second>;
+
+// rendered deep, we get the div output
+expect(deep(<First />).output()).toEqual(<div>second first</div>);
+// rendered shallow, we get the <Second> jsx node back
+expect(shallow(<First />).output()).toEqual(<Second>first</Second>);
+```
 
 ### `FindWrapper#filter(selector)`
 Returns a new `FindWrapper` with a subset of the previously selected elements given the selector argument.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test-jest": "jest --config jest.config.json",
     "test-jest-webpack": "jest-webpack",
-    "test": "npm run test-jest && npm run test-jest-webpack",
+    "test": "npm run test-jest",
     "pretest": "npm run lint",
     "lint": "eslint --ignore-pattern='!.eslintrc.js' --ext js,jsx src .eslintrc.js *.js"
   },

--- a/src/__snapshots__/shared-render.test.js.snap
+++ b/src/__snapshots__/shared-render.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deep: output matches snapshot 1`] = `
+VNode {
+  "attributes": undefined,
+  "children": Array [
+    "second first",
+  ],
+  "key": undefined,
+  "nodeName": "div",
+}
+`;
+
+exports[`shallow: output matches snapshot 1`] = `
+VNode {
+  "attributes": undefined,
+  "children": Array [
+    "first",
+  ],
+  "key": undefined,
+  "nodeName": [Function],
+}
+`;

--- a/src/preact-render-spy.js
+++ b/src/preact-render-spy.js
@@ -1,4 +1,4 @@
-const {render, rerender, Component} = require('preact');
+const {render, rerender, h, Component} = require('preact');
 const isEqual = require('lodash.isequal');
 
 const {isWhere} = require('./is-where');
@@ -260,7 +260,25 @@ class FindWrapper {
       throw new Error('preact-render-spy: Must have a result of a preact class or function component for .output()');
     }
 
-    return this.context.vdomMap.get(this[0]);
+    const getOutput = node => {
+      if (!node || typeof node !== 'object') {
+        return node;
+      }
+      // recursively resolve the node
+      let nodeOutput = node;
+      while (this.vdomMap.has(nodeOutput)) {
+        nodeOutput = this.vdomMap.get(nodeOutput);
+      }
+      const clone = h(
+        nodeOutput.nodeName,
+        nodeOutput.attributes,
+        nodeOutput.children && nodeOutput.children.map(getOutput)
+      );
+
+      return clone;
+    };
+
+    return getOutput(this[0]);
   }
 }
 

--- a/src/shared-render.test.js
+++ b/src/shared-render.test.js
@@ -2,62 +2,66 @@ const {h, Component} = require('preact');
 
 const {deep, shallow} = require('./preact-render-spy');
 
+class ReceivesProps extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {value: props.value};
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.setState({value: `_${newProps.value}_`});
+  }
+
+  render(props, {value}) {
+    return (
+      <div>{value}</div>
+    );
+  }
+}
+
+class Div extends Component {
+  render() {
+    return <div />;
+  }
+}
+
+class DivChildren extends Component {
+  render({children}) {
+    return <div>{children}</div>;
+  }
+}
+
+class ClickCount extends Component {
+  constructor(...args) {
+    super(...args);
+
+    this.state = {count: 0};
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {
+    this.setState({count: this.state.count + 1});
+  }
+
+  render({}, {count}) {
+    return <div onClick={this.onClick}>{count}</div>;
+  }
+}
+
+class DivCount extends Component {
+  render({count}) {
+    return <div>{count}</div>;
+  }
+}
+
+const DivCountStateless = ({count}) => <div>{count}</div>;
+
+const NullStateless = () => null;
+
+const Second = ({ children }) => <div>second {children}</div>;
+const First = () => <Second>first</Second>;
+
 const sharedTests = (name, func) => {
-  class ReceivesProps extends Component {
-    constructor(props) {
-      super(props);
-      this.state = {value: props.value};
-    }
-
-    componentWillReceiveProps(newProps) {
-      this.setState({value: `_${newProps.value}_`});
-    }
-
-    render(props, {value}) {
-      return (
-        <div>{value}</div>
-      );
-    }
-  }
-
-  class Div extends Component {
-    render() {
-      return <div />;
-    }
-  }
-
-  class DivChildren extends Component {
-    render({children}) {
-      return <div>{children}</div>;
-    }
-  }
-
-  class ClickCount extends Component {
-    constructor(...args) {
-      super(...args);
-
-      this.state = {count: 0};
-      this.onClick = this.onClick.bind(this);
-    }
-
-    onClick() {
-      this.setState({count: this.state.count + 1});
-    }
-
-    render({}, {count}) {
-      return <div onClick={this.onClick}>{count}</div>;
-    }
-  }
-
-  class DivCount extends Component {
-    render({count}) {
-      return <div>{count}</div>;
-    }
-  }
-
-  const DivCountStateless = ({count}) => <div>{count}</div>;
-
-  const NullStateless = () => null;
 
   it(`${name}: renders into fragment`, () => {
     const context = func(<Div />);
@@ -177,7 +181,18 @@ const sharedTests = (name, func) => {
     context.render(<ReceivesProps value="received" />);
     expect(context.text()).toBe('_received_');
   });
+
+  it(`${name}: output matches snapshot`, () => {
+    const context = func(<First />);
+    expect(context.output()).toMatchSnapshot();
+  });
 };
 
 sharedTests('deep', deep);
 sharedTests('shallow', shallow);
+
+
+it('output() is the same depth as the render method', () => {
+  expect(deep(<First />).output()).toEqual(<div>second first</div>);
+  expect(shallow(<First />).output()).toEqual(<Second>first</Second>);
+});


### PR DESCRIPTION
I wish the snapshot formatting of the VNode would include `[Function Second]` but `¯\_(ツ)_/¯`

Fixes #32 