### PR TITLE
Add npmignore file to remove non essentials from the bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.babelrc
+tests
+*.test.js
+node_modules
+.eslintrc.js
+.cache
+__snapshots__


### PR DESCRIPTION
This might also fix #41 - but we should probably do this anyway.