### PR TITLE
Add support for JSX find selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ We may expand this selector language in future versions, but it acheives our goa
 * `find('#selector')` - searches for any nodes with an `id` attribute that matches `selector`
 * `find('[selector]')` - searches for any nodes which have an attribute named `selector`
 * `find('Selector')` - searches for any nodes which have a nodeName that matches `Selector`,
-  this wills search for function/classes whos `name` is `Selector`, or `displayName` is `Selector`.
+  this will search for function/classes whos `name` is `Selector`, or `displayName` is `Selector`.
   If the `Selector` starts with a lower case letter, it will also check for tags like `div`.
+* `find(<Selector simple="attributes" class="working" />)` - searches for any nodes whos nodeName equals `Selector`
+  and attributes match the ones given in the JSX.  **NOTE:** This does not support children, just simple attributes.
+  Can be useful to find components from minified output that don't include display names.
+  `.find(<ImportedComponent />)` will look for JSX nodes using the same `ImportedComponent` function.
 
 This will return you a [`FindWrapper`](#findwrapper) which has other useful methods for testing.
 

--- a/src/is-where.js
+++ b/src/is-where.js
@@ -85,11 +85,11 @@ const _isWhere = (where, target) => {
       if (!attr) {
         attr = [];
       }
-      else if (typeof attr === 'object') {
-        attr = Object.keys(attr).filter(key => attr[key]);
-      }
       else if (typeof attr === 'string') {
         attr = attr.split(/\s+/);
+      }
+      else {
+        return false;
       }
 
       if (!attr || attr.indexOf(value) === -1) {

--- a/src/is-where.js
+++ b/src/is-where.js
@@ -82,7 +82,10 @@ const _isWhere = (where, target) => {
 
     if (key === 'class' || key === 'className') {
       let attr = target.class || target.className;
-      if (typeof attr === 'object') {
+      if (!attr) {
+        attr = [];
+      }
+      else if (typeof attr === 'object') {
         attr = Object.keys(attr).filter(key => attr[key]);
       }
       else if (typeof attr === 'string') {

--- a/src/is-where.js
+++ b/src/is-where.js
@@ -1,28 +1,72 @@
 const entries = require('object.entries');
 
+const ATTRIBUTE_PRESENT = {exists: true};
+
 const _isWhere = (where, target) => {
+  // Check each key from where
   for (const [key, value] of entries(where)) {
+
+    // If the key is set, but value is undefined, we ignore it
+    if (typeof value === 'undefined') {
+      continue;
+    }
+
+    // Allow a way to check for the pressenece of an attribute with that name.
+    if (value === ATTRIBUTE_PRESENT) {
+      if (!(key in target)) {
+        return false;
+      }
+      continue;
+    }
+
+    // Array checks
+    if (Array.isArray(value)) {
+      // [x,y,z] - allow the target value to be x, y, OR z
+      if (value.length && !value.some(test => target[key] === test)) {
+        return false;
+      }
+      continue;
+    }
+
+    // Null check
+    if (value === null) {
+      if (target[key] !== null) {
+        return false;
+      }
+      continue;
+    }
+
+    // Object checks (recursion)
     if (typeof value === 'object') {
       if (!(Boolean(target[key]) && _isWhere(value, target[key]))) {
         return false;
       }
+      continue;
     }
-    else if (key === 'nodeName') {
+
+    // nodeName attributes
+    if (key === 'nodeName') {
+      // if the target is a component
       if (typeof target.nodeName === 'function') {
-        if (target.nodeName.name !== value && target.nodeName.displayName !== value) {
+        // match the raw function value, name value, or displayName value
+        if (target.nodeName !== value && target.nodeName.name !== value && target.nodeName.displayName !== value) {
           return false;
         }
       }
       else if (/[a-z]/.test(value[0])) {
+        // nodeName starts with a lowercase letter = standard string nodenames
         if (target.nodeName !== value) {
           return false;
         }
       }
       else {
+        // some unsupported nodeName query
         return false;
       }
+      continue;
     }
-    else if (key === 'class') {
+
+    if (key === 'class' || key === 'className') {
       let attr = target.class || target.className;
       if (typeof attr === 'object') {
         attr = Object.keys(attr).filter(key => attr[key]);
@@ -34,18 +78,10 @@ const _isWhere = (where, target) => {
       if (!attr || attr.indexOf(value) === -1) {
         return false;
       }
+      continue;
     }
-    else if (value === null) {
-      if (!(key in target)) {
-        return false;
-      }
-    }
-    else if (Array.isArray(value)) {
-      if (!value.some(test => target[key] === test)) {
-        return false;
-      }
-    }
-    else if (!target || target[key] !== value) {
+
+    if (!target || target[key] !== value) {
       return false;
     }
   }
@@ -57,4 +93,5 @@ const isWhere = where => value => _isWhere(where, value);
 module.exports = {
   _isWhere,
   isWhere,
+  ATTRIBUTE_PRESENT,
 };

--- a/src/is-where.js
+++ b/src/is-where.js
@@ -2,6 +2,29 @@ const entries = require('object.entries');
 
 const ATTRIBUTE_PRESENT = {exists: true};
 
+/**
+ * _isWhere matching checks
+ * `where` should be an object with keys you wish to match against a `target` object
+ *
+ * { attr: ATTRIBUTE_PRESENT } - If the value of a key is the ATTRIBUTE_PRESENT constant
+ *                               we return false if the attribute is not a property of that
+ *                               object. `'attr' in target`
+ *
+ * { attr: null } - Asserts that `target.attr === null`
+ *
+ * { attr: anotherObject } - Recurses using `_isWhere(where.attr, target.attr)`
+ *
+ * { nodeName: String|Function } - Matches value checking `target.nodeName`.
+ *     When `target.nodeName` is a function, it tests that `name`, `displayName` match the
+ *     String given, or when a Function, that they are equal.
+ *
+ * { class: String } or { className: String } - Tests the `target.class || target.className` for
+ *     the presence of the given string.  Will "split" the target class attribute into an array on
+ *     whitespace, and returns false if the given class isn't present.
+ *
+ * { attr: value } - All other value/attribute combinations are a simple === test
+ */
+
 const _isWhere = (where, target) => {
   // Check each key from where
   for (const [key, value] of entries(where)) {
@@ -14,15 +37,6 @@ const _isWhere = (where, target) => {
     // Allow a way to check for the pressenece of an attribute with that name.
     if (value === ATTRIBUTE_PRESENT) {
       if (!(key in target)) {
-        return false;
-      }
-      continue;
-    }
-
-    // Array checks
-    if (Array.isArray(value)) {
-      // [x,y,z] - allow the target value to be x, y, OR z
-      if (value.length && !value.some(test => target[key] === test)) {
         return false;
       }
       continue;

--- a/src/is-where.test.js
+++ b/src/is-where.test.js
@@ -30,6 +30,21 @@ it('tests Component names', () => {
   expect(isWhere({nodeName: 'displayName'})(<DisplayNamedFunc />)).toBeTruthy();
 });
 
+it('tests vdom names', () => {
+  class Node extends Component {}
+  const NodelessConst = () => {};
+  function NodelessFunc() {}
+  function DisplayNamedFunc() {}
+  DisplayNamedFunc.displayName = 'displayName';
+
+  expect(isWhere(<Node />)(<Node />)).toBeTruthy();
+  expect(isWhere(<NodelessConst />)(<NodelessConst />)).toBeTruthy();
+  expect(isWhere(<NodelessFunc />)(<NodelessFunc />)).toBeTruthy();
+  expect(isWhere(<DisplayNamedFunc />)(<DisplayNamedFunc />)).toBeTruthy();
+});
+
+
+
 it('tests nested attributes', () => {
   expect(isWhere({attributes: {class: 'class'}})(<div class="class" />))
     .toBeTruthy();

--- a/src/is-where.test.js
+++ b/src/is-where.test.js
@@ -11,10 +11,8 @@ it('tests class names', () => {
   expect(testClass(<div class="test" />)).toBeTruthy();
   expect(testClass(<div class="nottest" />)).toBeFalsy();
   expect(testClass(<div class="nottest and test" />)).toBeTruthy();
-  expect(testClass(<div class={{nottest: false, test: true }} />)).toBeTruthy();
-  expect(testClass(<div class={{test: false}} />)).toBeFalsy();
+  expect(testClass(<div className={null} />)).toBeFalsy();
   expect(testClass(<div className="test" />)).toBeTruthy();
-  expect(testClass(<div className={{test: true}} />)).toBeTruthy();
 });
 
 it('tests Component names', () => {

--- a/src/sel-to-where.js
+++ b/src/sel-to-where.js
@@ -1,4 +1,9 @@
+const {ATTRIBUTE_PRESENT} = require('./is-where');
+
 const selToWhere = sel => {
+  if (typeof sel === 'object') {
+    return sel;
+  }
   if (/^\./.test(sel)) {
     return {attributes: {class: sel.substring(1)}};
   }
@@ -6,11 +11,10 @@ const selToWhere = sel => {
     return {attributes: {id: sel.substring(1)}};
   }
   else if (/^\[/.test(sel)) {
-    return {attributes: {[sel.substring(1, sel.length - 1)]: null}};
+    return {attributes: {[sel.substring(1, sel.length - 1)]: ATTRIBUTE_PRESENT}};
   }
 
   return {nodeName: sel};
-
 };
 
 module.exports = {

--- a/src/sel-to-where.test.js
+++ b/src/sel-to-where.test.js
@@ -1,4 +1,6 @@
+const {h} = require('preact');
 const {selToWhere} = require('./sel-to-where');
+const {ATTRIBUTE_PRESENT} = require('./is-where');
 
 it('node names', () => {
   expect(selToWhere('div')).toEqual({nodeName: 'div'});
@@ -14,6 +16,10 @@ it('ids', () => {
 });
 
 it('attributes', () => {
-  expect(selToWhere('[attr]')).toEqual({attributes: {attr: null}});
-  expect(selToWhere('[onClick]')).toEqual({attributes: {onClick: null}});
+  expect(selToWhere('[attr]')).toEqual({attributes: {attr: ATTRIBUTE_PRESENT}});
+  expect(selToWhere('[onClick]')).toEqual({attributes: {onClick: ATTRIBUTE_PRESENT}});
+});
+
+it('vdom', () => {
+  expect(selToWhere(<div testAttr={true} />)).toEqual(<div testAttr={true} />);
 });

--- a/src/shared-render.test.js
+++ b/src/shared-render.test.js
@@ -153,6 +153,15 @@ const sharedTests = (name, func) => {
     expect(context.filter('span').length).toBe(0);
   });
 
+  it(`${name}: filters components using vdom`, () => {
+    const context = func(<div><NullStateless class="first" something={null} /><NullStateless class="second" /></div>);
+    expect(context.find(<NullStateless />).length).toBe(2);
+    expect(context.find(<NullStateless class="first" />).length).toBe(1);
+    expect(context.find(<NullStateless something={null} />).length).toBe(1);
+    expect(context.filter(<div />).length).toBe(1);
+    expect(context.filter(<span />).length).toBe(0);
+  });
+
   it(`${name}: output returns vdom output by a Component`, () => {
     const context = func(<DivChildren><span /></DivChildren>);
     expect(() => context.find('div').output()).toThrow();

--- a/src/shared-render.test.js
+++ b/src/shared-render.test.js
@@ -264,6 +264,20 @@ const sharedTests = (name, func) => {
     expect(context.text()).toEqual('2');
   });
 
+  it(`${name}: find by class works with null and undefined class and className`, () => {
+    const context = func(<div class={null}>test</div>);
+    expect(() => context.find('.test')).not.toThrow();
+
+    context.render(<div className={null}>test</div>);
+    expect(() => context.find('.test')).not.toThrow();
+
+    context.render(<div class={undefined}>test</div>);
+    expect(() => context.find('.test')).not.toThrow();
+
+    context.render(<div className={undefined}>test</div>);
+    expect(() => context.find('.test')).not.toThrow();
+  });
+
   describe('warnings', () => {
     const warn = console.warn;
     let spy;

--- a/src/shared-render.test.js
+++ b/src/shared-render.test.js
@@ -265,16 +265,16 @@ const sharedTests = (name, func) => {
   });
 
   it(`${name}: find by class works with null and undefined class and className`, () => {
-    const context = func(<div class={null}>test</div>);
+    const context = func(<DivChildren><div class={null}>test</div></DivChildren>);
     expect(() => context.find('.test')).not.toThrow();
 
-    context.render(<div className={null}>test</div>);
+    context.render(<DivChildren><div className={null}>test</div></DivChildren>);
     expect(() => context.find('.test')).not.toThrow();
 
-    context.render(<div class={undefined}>test</div>);
+    context.render(<DivChildren><div class={undefined}>test</div></DivChildren>);
     expect(() => context.find('.test')).not.toThrow();
 
-    context.render(<div className={undefined}>test</div>);
+    context.render(<DivChildren><div className={undefined}>test</div></DivChildren>);
     expect(() => context.find('.test')).not.toThrow();
   });
 


### PR DESCRIPTION
Adds documentation/support for the following features

* `find(<Selector simple="attributes" class="working" />)` - searches for any nodes whos nodeName equals `Selector` and attributes match the ones given in the JSX.  **NOTE:** This does not support children, just simple attributes. Can be useful to find components from minified output that don't include display names. `.find(<ImportedComponent />)` will look for JSX nodes using the same `ImportedComponent` function.

Now should also fix #47 