### PR TITLE
chore: Rename Options -> ToStringOptions in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ interface ShallowFunction {
     <P, S>(vdom: JSX.Element): RenderContext<P, S>;
 }
 
-interface Options {
+interface ToStringOptions {
     attributeHook: Function;
     functionNames: boolean;
     functions: boolean;
@@ -116,7 +116,7 @@ interface Options {
 export const config: {
     SPY_PRIVATE_KEY: string;
     createFragment: () => Document | Element;
-    toStringOptions: Options;
+    toStringOptions: ToStringOptions;
 }
 
 export const deep: DeepFunction;


### PR DESCRIPTION
Rename to ToStringOptions in index.d.ts for readability so its more
clear that the interface is for stating how something will be
stringified instead of the more opaque Options name.