### PR TITLE
Add preact.VNode to signature for find()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ export interface FindWrapper<P, S> {
      * Selects descendents of the elements previously selected. Returns a new `FindWrapper` with the newly selected
      * elements.
      **/
-    find<Q, T>(selector: string): FindWrapper<Q, T>;
+    find<Q, T>(selector: preact.VNode | string): FindWrapper<Q, T>;
 
     /** Requires a single `Component` or functional node. Returns the raw vdom output of the given component. */
     output(): preact.VNode;


### PR DESCRIPTION
Adds preact.VNode to the union-type in the find() signature

Fixes #76 