### PR TITLE
Add typing for using find with a JSX Element

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ export interface FindWrapper<P, S> {
      * Selects descendents of the elements previously selected. Returns a new `FindWrapper` with the newly selected
      * elements.
      **/
-    find<Q, T>(selector: string): FindWrapper<Q, T>;
+    find<Q, T>(selector: string | JSX.Element): FindWrapper<Q, T>;
 
     /** Requires a single `Component` or functional node. Returns the raw vdom output of the given component. */
     output(): preact.VNode;

--- a/tests/usage.tsx
+++ b/tests/usage.tsx
@@ -61,6 +61,7 @@ function exerciseFindWrapper<P, S, K extends keyof P>(wrapper: FindWrapper<P, S>
     const atWrapper: FindWrapper<any, any> = wrapper.at<any, any>(0);
     const filterWrapper: FindWrapper<any, any> = wrapper.filter<any, any>("selector");
     const findWrapper: FindWrapper<any, any> = wrapper.find<any, any>("selector");
+    const findWrapper2: FindWrapper<any, any> = wrapper.find<any, any>(<CompA />);
     const attrs: P = wrapper.attrs();
     const attr: P[K] = wrapper.attr(attrKey);
     let simulate: void = wrapper.simulate("click");


### PR DESCRIPTION
Add missing type for calling `find` with a JSX.Element